### PR TITLE
Add Python 2.6 compatibility

### DIFF
--- a/name_cleaver/name_cleaver.py
+++ b/name_cleaver/name_cleaver.py
@@ -397,7 +397,7 @@ class IndividualNameCleaver(BaseNameCleaver):
         name = re.sub('\(\s*([^)]+)\s*\)', '(\1)', name)
 
         # get rid of trailing '& mrs'
-        name = re.sub(' \& mrs\.?$', '', name, flags=re.IGNORECASE)
+        name = re.sub(' (?i)\& mrs\.?$', '', name)
 
         return name
 

--- a/name_cleaver/test_name_cleaver.py
+++ b/name_cleaver/test_name_cleaver.py
@@ -1,7 +1,10 @@
 from name_cleaver import PoliticianNameCleaver, OrganizationNameCleaver, \
         IndividualNameCleaver, UnparseableNameException
 
-import unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 
 class TestPoliticianNameCleaver(unittest.TestCase):


### PR DESCRIPTION
Not sure how useful this is to you all, but wanted to share anyway.

In Python 2.6, `re.sub` doesn't handle the 'flags' argument. This commit moves the ignore case flag to inside the regex to get around the issue.

Added the unittest2 stuff so the test suite can be easily ran from 2.6, too.

Test suite passes on both 2.7 and 2.6.
